### PR TITLE
make recorded date on history page muted

### DIFF
--- a/PeriodTracker/App.xaml
+++ b/PeriodTracker/App.xaml
@@ -8,6 +8,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+                <ResourceDictionary Source="Resources/Styles/CustomStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/PeriodTracker/Resources/Styles/CustomStyles.xaml
+++ b/PeriodTracker/Resources/Styles/CustomStyles.xaml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+    <Style TargetType="Label" x:Key="Muted">
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+        <Setter Property="FontAttributes" Value="Italic" />
+        <Setter Property="FontSize" Value="9" />
+        <Setter Property="HorizontalOptions" Value="Center" />
+        <Setter Property="HorizontalTextAlignment" Value="Center" />
+    </Style>
+
+
+</ResourceDictionary>

--- a/PeriodTracker/Views/HistoryPage.xaml
+++ b/PeriodTracker/Views/HistoryPage.xaml
@@ -77,9 +77,11 @@
                                     Grid.Column="0">
                                     <Label
                                         Text="Recorded: "
+                                        Style="{StaticResource Muted}"
                                         />
                                     <Label
                                         Text="{Binding RecordedDateText}"
+                                        Style="{StaticResource Muted}"
                                         />
                                 </HorizontalStackLayout>
                                 <ImageButton


### PR DESCRIPTION
The recorded date value for entries on the history page will now appear under intensified so as not to detract from the start date value.

Resolves #5