### PR TITLE
refactor formatting display of dates

### DIFF
--- a/PeriodTracker/Models/Cycle.cs
+++ b/PeriodTracker/Models/Cycle.cs
@@ -3,9 +3,7 @@
 public class Cycle: IEquatable<Cycle>
 {
     public DateTime RecordedDate {get; init;}
-    public string RecordedDateText => RecordedDate.ToString("d");
     public DateTime StartDate {get; init;}
-    public string StartDateText => StartDate.ToString("d");
 
     public bool Equals(Cycle? other)
     {

--- a/PeriodTracker/ViewModels/HistoryViewModel.cs
+++ b/PeriodTracker/ViewModels/HistoryViewModel.cs
@@ -26,7 +26,7 @@ public class HistoryViewModel : ViewModelBase, IEventBusListener
         var confirmDelete = await ServiceHelper.GetService<IAlertService>()
             !.ShowConfirmationAsync(
                 "Confirm delete",
-                $"Are you sure you want to delete cycle with start date \"{cycle.StartDateText}\"?");
+                $"Are you sure you want to delete cycle with start date \"{cycle.StartDate:d}\"?");
 
         if (!confirmDelete) return;
 

--- a/PeriodTracker/Views/HistoryPage.xaml
+++ b/PeriodTracker/Views/HistoryPage.xaml
@@ -69,7 +69,7 @@
                                         Text="Start date: "
                                         />
                                     <Label
-                                        Text="{Binding StartDateText}"
+                                        Text="{Binding StartDate, StringFormat='{0:d}'}"
                                         />
                                 </HorizontalStackLayout>
                                 <HorizontalStackLayout
@@ -80,7 +80,7 @@
                                         Style="{StaticResource Muted}"
                                         />
                                     <Label
-                                        Text="{Binding RecordedDateText}"
+                                        Text="{Binding RecordedDate, StringFormat='{0:d}'}"
                                         Style="{StaticResource Muted}"
                                         />
                                 </HorizontalStackLayout>


### PR DESCRIPTION
Using a proptery to expose StartDate and RecordedDate as text was a workaround for not knowing how to get MAUI XAML to format dates as strings. I figured out how to do that so we don't need those specific text properties.

Also, those text properties would make converting to EntityFramework hard.