### PR TITLE
fix crash when loading import export page

### DIFF
--- a/PeriodTracker/PeriodTracker.csproj
+++ b/PeriodTracker/PeriodTracker.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<!-- Versions -->
-		<ApplicationDisplayVersion>0.4.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>0.4.1</ApplicationDisplayVersion>
 		<ApplicationVersion>$([System.DateTime]::UtcNow.ToString('yyMMddHH'))</ApplicationVersion>
 
 		<TargetFrameworks>net8.0-android;net8.0</TargetFrameworks>

--- a/PeriodTracker/Views/ImportExportPage.xaml
+++ b/PeriodTracker/Views/ImportExportPage.xaml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:system="clr-namespace:System;assembly=netstandard"
              xmlns:mauitoolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             x:Class="PeriodTracker.ImportExportPage"
+             xmlns:system="clr-namespace:System;assembly=netstandard"
              xmlns:viewmodel="clr-namespace:PeriodTracker.ViewModels"
+             x:Class="PeriodTracker.ImportExportPage"
              x:DataType="viewmodel:ImportExportViewModel"
              Title="Import/Export">
 
@@ -30,7 +30,6 @@ Using Export, you can take the data from this device and put in on a different d
             Clicked="OnExportClicked"
             IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
             HorizontalOptions="Fill" />
-        <BoxView HeightRequest="1" Color="{StaticResource Grey100}" />
         <Label Text="Import"
                 Style="{StaticResource SubHeadline}"
                 HorizontalOptions="Center"/>


### PR DESCRIPTION
Removed BoxView from Import/Export page. This control
was causing the app to hang and, on some devices, crash.