### PR TITLE
print more info for error messages

### DIFF
--- a/PeriodTracker/PeriodTracker.csproj
+++ b/PeriodTracker/PeriodTracker.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<!-- Versions -->
-		<ApplicationDisplayVersion>0.4.1</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>0.4.2</ApplicationDisplayVersion>
 		<ApplicationVersion>$([System.DateTime]::UtcNow.ToString('yyMMddHH'))</ApplicationVersion>
 
 		<TargetFrameworks>net8.0-android;net8.0</TargetFrameworks>

--- a/PeriodTracker/Utilities/ExceptionHelper.cs
+++ b/PeriodTracker/Utilities/ExceptionHelper.cs
@@ -1,0 +1,20 @@
+using System.Text;
+
+namespace PeriodTracker;
+
+public static class ExceptionHelper
+{
+    public static string GetMessages(Exception ex)
+    {
+        var sb = new StringBuilder();
+        while(ex is not null)
+        {
+            sb.Append(ex.Message);
+            sb.Append(' ');
+
+            ex = ex.InnerException!;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/PeriodTracker/ViewModels/ImportExportViewModel.cs
+++ b/PeriodTracker/ViewModels/ImportExportViewModel.cs
@@ -47,7 +47,7 @@ public partial class ImportExportViewModel: ViewModelBase
         catch(Exception ex)
         {
             Debug.WriteLine($"Error during export: {ex}");
-            await _alertService.ShowAlertAsync("Error", ex.Message);
+            await _alertService.ShowAlertAsync("Error", ExceptionHelper.GetMessages(ex));
         }
         finally
         {
@@ -83,7 +83,7 @@ public partial class ImportExportViewModel: ViewModelBase
         catch(Exception ex)
         {
             Debug.WriteLine($"Error during export: {ex}");
-            await _alertService.ShowAlertAsync("Error", ex.Message);
+            await _alertService.ShowAlertAsync("Error", ExceptionHelper.GetMessages(ex));
         }
         finally
         {


### PR DESCRIPTION
When an exception is caught and displayed to a user, more information will be displayed instead of just a generic top level message.