### PR TITLE
feat: add estimated end of period

### DIFF
--- a/PeriodTracker/Converters/StringNotNullOrEmptyToBoolConverter.cs
+++ b/PeriodTracker/Converters/StringNotNullOrEmptyToBoolConverter.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+
+namespace PeriodTracker.Converters;
+
+public class StringNotNullOrEmptyToBoolConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return !string.IsNullOrEmpty(value as string);
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/PeriodTracker/ViewModels/MainViewModel.cs
+++ b/PeriodTracker/ViewModels/MainViewModel.cs
@@ -8,6 +8,7 @@ namespace PeriodTracker.ViewModels;
 public partial class MainViewModel : ViewModelBase, IEventBusListener
 {
     private const int _defaultCycleLengthDays = 29;
+    private const int _defaultPeriodLengthDays = 6;
     private bool dataRefreshRequired = true;
 
     private readonly IAlertService _alertService;
@@ -40,6 +41,11 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
 
     [ObservableProperty]
     private string nextCycleStartDateText = string.Empty;
+
+    [ObservableProperty]
+    private string periodEndDateText = string.Empty;
+    [ObservableProperty]
+    private string periodEndText = string.Empty;
 
     public void HandleEvent(EventBusBroadcastedEvent @event){
         if (@event != EventBusBroadcastedEvent.CyclesUpdated) return;
@@ -81,6 +87,8 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
                 .AddDays(_defaultCycleLengthDays)
                 .ToString("D");
 
+            UpdatePeriodEndText(mostRecentCycleStart);
+
             await CheckForUpdates();
         }
         finally{
@@ -108,6 +116,24 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
                 "Update available",
                 $"New version {latestVersion:3} is available. For instructions about how to update, see About > How to update."
             );
+    }
+
+    private void UpdatePeriodEndText(DateTime cycleStart)
+    {
+        var periodEndDate = cycleStart.AddDays(_defaultPeriodLengthDays);
+        var daysRemaining = (cycleStart == default)
+            ? -1
+            : _defaultPeriodLengthDays - (_dateTimeService.Today - cycleStart).Days;
+
+        PeriodEndDateText = daysRemaining > 0 ? periodEndDate.ToString("D") : string.Empty;
+        PeriodEndText = daysRemaining switch
+        {
+            // > 0 => $"The last day of your period should be {periodEndDate:D} (in {daysRemaining} days).",
+            > 1 => $"Last day of your period should be in {daysRemaining} days:",
+            1 => $"Last day of your period should be in {daysRemaining} day:",
+            0 => "Today should be the last day of your period.",
+            _ => string.Empty
+        };
     }
 
 }

--- a/PeriodTracker/Views/HistoryPage.xaml
+++ b/PeriodTracker/Views/HistoryPage.xaml
@@ -48,7 +48,7 @@
 
             <Button
                 Grid.Row="0"
-                Text="Record start of period"
+                Text="Record start of your period"
                 Clicked="OnRecordNewClicked"
                 IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
                 HorizontalOptions="Fill" />

--- a/PeriodTracker/Views/MainPage.xaml
+++ b/PeriodTracker/Views/MainPage.xaml
@@ -3,12 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:mauitoolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="PeriodTracker.MainPage"
+             xmlns:converters="clr-namespace:PeriodTracker.Converters"
              xmlns:viewmodel="clr-namespace:PeriodTracker.ViewModels"
              x:DataType="viewmodel:MainViewModel">
 
     <ContentPage.Resources>
         <ResourceDictionary>
             <mauitoolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+            <converters:StringNotNullOrEmptyToBoolConverter x:Key="StringNotNullOrEmptyToBoolConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -16,24 +18,6 @@
         <VerticalStackLayout
             Padding="30,0"
             Spacing="25">
-
-            <!-- <Label
-                Text="Hello, World!"
-                Style="{StaticResource Headline}"
-                SemanticProperties.HeadingLevel="Level1" /> -->
-
-            <!-- <Label
-                Text="Welcome to &#10;.NET Multi-platform App UI"
-                Style="{StaticResource SubHeadline}"
-                SemanticProperties.HeadingLevel="Level2"
-                SemanticProperties.Description="Welcome to dot net Multi platform App U I" /> -->
-
-            <!-- <Button
-                x:Name="CounterBtn"
-                Text="Click me" 
-                SemanticProperties.Hint="Counts the number of times you click"
-                Clicked="OnCounterClicked"
-                HorizontalOptions="Fill" /> -->
 
                 <Label
                     Text="Days until next period"
@@ -45,37 +29,59 @@
                     IsVisible="{Binding IsBusy}"
                     Color="{StaticResource Primary}" />
 
-                <Label
-                    Text="{Binding DaysUntilNextCycleText}"
+                <VerticalStackLayout
                     IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-                    Style="{StaticResource SubHeadline}"
-                    SemanticProperties.HeadingLevel="Level2"/>
-
-                <Label
-                    Text="OVERDUE!"
-                    IsVisible="{Binding IsCycleStartOverdue}"
-                    Style="{StaticResource SubHeadline}"
-                    TextColor="Crimson"
-                    />
-
-                <VerticalStackLayout>
+                    Spacing="25"
+                    >
                     <Label
-                        Text="Next period expected to start on:"
+                        Text="{Binding DaysUntilNextCycleText}"
                         IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-                        HorizontalOptions="Center"
-                        />
+                        Style="{StaticResource SubHeadline}"
+                        SemanticProperties.HeadingLevel="Level2"/>
+
                     <Label
-                        Text="{Binding NextCycleStartDateText}"
-                        IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-                        HorizontalOptions="Center"
+                        Text="OVERDUE!"
+                        IsVisible="{Binding IsCycleStartOverdue}"
+                        Style="{StaticResource SubHeadline}"
+                        TextColor="Crimson"
                         />
+
+                    <VerticalStackLayout
+                        IsVisible="{Binding PeriodEndText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
+                        >
+                        <Label
+                            Text="{Binding PeriodEndText}"
+                            IsVisible="{Binding PeriodEndText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
+                            HorizontalOptions="Start"
+                            />
+                        <Label
+                            Text="{Binding PeriodEndDateText}"
+                            IsVisible="{Binding PeriodEndText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
+                            HorizontalOptions="End"
+                            Margin="0,0,10,0"
+                            />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout>
+                        <Label
+                            Text="Next period expected to start on:"
+                            IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+                            HorizontalOptions="Start"
+                            />
+                        <Label
+                            Text="{Binding NextCycleStartDateText}"
+                            IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+                            HorizontalOptions="End"
+                            Margin="0,0,10,0"
+                            />
+                    </VerticalStackLayout>
+
+                    <Button
+                        Text="Record start of period"
+                        IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+                        Clicked="OnRecordNewClicked"
+                        HorizontalOptions="Fill" />
                 </VerticalStackLayout>
-
-                <Button
-                    Text="Record start of period"
-                    IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-                    Clicked="OnRecordNewClicked"
-                    HorizontalOptions="Fill" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/PeriodTracker/Views/MainPage.xaml
+++ b/PeriodTracker/Views/MainPage.xaml
@@ -20,7 +20,7 @@
             Spacing="25">
 
                 <Label
-                    Text="Days until next period"
+                    Text="Days until your next period"
                     Style="{StaticResource Headline}"
                     SemanticProperties.HeadingLevel="Level1"/>
 
@@ -40,7 +40,7 @@
                         SemanticProperties.HeadingLevel="Level2"/>
 
                     <Label
-                        Text="OVERDUE!"
+                        Text="Your period is overdue!"
                         IsVisible="{Binding IsCycleStartOverdue}"
                         Style="{StaticResource SubHeadline}"
                         TextColor="Crimson"
@@ -64,7 +64,7 @@
 
                     <VerticalStackLayout>
                         <Label
-                            Text="Next period expected to start on:"
+                            Text="Your next period is expected to start on:"
                             IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
                             HorizontalOptions="Start"
                             />
@@ -77,7 +77,7 @@
                     </VerticalStackLayout>
 
                     <Button
-                        Text="Record start of period"
+                        Text="Record start of your period"
                         IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
                         Clicked="OnRecordNewClicked"
                         HorizontalOptions="Fill" />

--- a/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
+++ b/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
@@ -11,8 +11,70 @@ public class MainViewModelTests: BaseTest, IClassFixture<TemporaryDirectoryFixtu
 {
     private readonly TemporaryDirectoryFixture _tempDir;
 
+    private readonly Mock<IAlertService> _mockAlertService = new Mock<IAlertService>();
+    private readonly Mock<IAppInfo> _mockAppInfo = new Mock<IAppInfo>();
+    private readonly Mock<IDateTimeService> _mockDateTimeService = new Mock<IDateTimeService>();
+    private readonly Mock<IDbContextProvider> _mockDbContextProvider = new Mock<IDbContextProvider>();
+    private readonly Mock<IUpdateService> _mockUpdateService = new Mock<IUpdateService>();
+    private readonly Mock<IUpdateServiceProvider> _mockUpdateServiceProvider = new Mock<IUpdateServiceProvider>();
+
     public MainViewModelTests(TemporaryDirectoryFixture tempDirFixture){
         _tempDir = tempDirFixture;
+    }
+
+    private void SetupMocks(DirectoryInfo testTempDir, DateTime today)
+    {
+        _mockDateTimeService.Setup(s => s.Today).Returns(today);
+
+        _mockDbContextProvider.Setup(p => p.GetContext())
+            .ReturnsAsync(new AppDbContext(CreateDbContextOptions(testTempDir), true));
+
+        _mockUpdateServiceProvider.Setup(p => p.GetUpdateService())
+            .Returns(_mockUpdateService.Object);
+    }
+
+    [Theory]
+    [InlineData("2026-04-16", "2026-04-16", "2026-04-22", "Last day of your period should be in 6 days:")]
+    [InlineData("2026-04-16", "2026-04-17", "2026-04-22", "Last day of your period should be in 5 days:")]
+    [InlineData("2026-04-16", "2026-04-21", "2026-04-22", "Last day of your period should be in 1 day:")]
+    [InlineData("2026-04-16", "2026-04-22", "", "Today should be the last day of your period.")]
+    [InlineData("2026-04-16", "2026-04-23", "", "")]
+    public async Task LoadAsync_CalculatePeriodEndCorrectly(
+        string inpMostRecentCycleStartStr,
+        string inpTodayStr,
+        string expPeriodEndDateText,
+        string expPeriodEndText)
+    {
+        var today = DateTime.Parse(inpTodayStr);
+
+        var testTempDir = _tempDir.CreateTestCaseDirectory(inpTodayStr);
+        var seedData = new SeedData {
+            Cycles = new List<Cycle> {
+                new Cycle { StartDate = DateTime.Parse(inpMostRecentCycleStartStr) }
+            }
+        };
+        await SetupDatabase(testTempDir, seedData);
+
+        SetupMocks(testTempDir, today);
+
+        _mockUpdateService.Setup(s => s.GetShouldCheckForUpdates())
+            .ReturnsAsync(false);
+
+        var actor = new MainViewModel(
+            _mockDbContextProvider.Object,
+            _mockDateTimeService.Object,
+            _mockUpdateServiceProvider.Object,
+            _mockAppInfo.Object,
+            _mockAlertService.Object);
+
+        await actor.LoadAsync();
+
+        expPeriodEndDateText = string.IsNullOrEmpty(expPeriodEndDateText)
+            ? string.Empty
+            : DateTime.Parse(expPeriodEndDateText).ToString("D");
+
+        Assert.Equal(expPeriodEndDateText, actor.PeriodEndDateText);
+        Assert.Equal(expPeriodEndText, actor.PeriodEndText);
     }
 
     [Theory]


### PR DESCRIPTION
Added calculation and display of estimated end of period date on the main page, based on the most recent cycle start date and a default period length.

Make some text more user-friendly and less robotic.