### PR TITLE
feat: add fertile window range

### DIFF
--- a/PeriodTracker/ViewModels/MainViewModel.cs
+++ b/PeriodTracker/ViewModels/MainViewModel.cs
@@ -180,12 +180,12 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
             ? -1
             : _defaultPeriodLengthDays - (_dateTimeService.Today - cycleStart).Days;
 
-        PeriodEndDateText = daysRemaining > 0 ? periodEndDate.ToString("D") : string.Empty;
+        PeriodEndDateText = daysRemaining > 1 ? periodEndDate.ToString("D") : string.Empty;
         PeriodEndText = daysRemaining switch
         {
             // > 0 => $"The last day of your period should be {periodEndDate:D} (in {daysRemaining} days).",
             > 1 => $"Last day of your period should be in {daysRemaining} days:",
-            1 => $"Last day of your period should be in {daysRemaining} day:",
+            1 => $"Tomorrow should be the last day of your period.",
             0 => "Today should be the last day of your period.",
             _ => string.Empty
         };

--- a/PeriodTracker/ViewModels/MainViewModel.cs
+++ b/PeriodTracker/ViewModels/MainViewModel.cs
@@ -40,6 +40,11 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
     private bool isCycleStartOverdue;
 
     [ObservableProperty]
+    private string fertileWindowDateText = string.Empty;
+    [ObservableProperty]
+    private string fertileWindowText = string.Empty;
+
+    [ObservableProperty]
     private string nextCycleStartDateText = string.Empty;
 
     [ObservableProperty]
@@ -87,6 +92,7 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
                 .AddDays(_defaultCycleLengthDays)
                 .ToString("D");
 
+            UpdateFertileWindowText(mostRecentCycleStart);
             UpdatePeriodEndText(mostRecentCycleStart);
 
             await CheckForUpdates();
@@ -116,6 +122,55 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
                 "Update available",
                 $"New version {latestVersion:3} is available. For instructions about how to update, see About > How to update."
             );
+    }
+
+    private void UpdateFertileWindowText(DateTime cycleStart)
+    {
+        FertileWindowText = string.Empty;
+        FertileWindowDateText = string.Empty;
+
+        if (cycleStart == default)
+            return;
+
+        // Fertile window is considered to be the 3 days leading up to ovulation,
+        // the day of ovulation (which occurs around 14-15 days after the current
+        // cycle starts), and the day after ovulation.
+        // NOTE: Without tracking ovulation more precisely, this is just an
+        // estimate based on the average cycle length and ovulation timing.
+        // NOTE: Ovulation day can also be calculated by halving the cycle length.
+        // This is probably the way to go to allow for different cycle lengths.
+
+        var ovulationDay = cycleStart.AddDays(Math.Floor(_defaultCycleLengthDays / 2.0));
+
+        var fertileWindowStart = ovulationDay.AddDays(-3);
+        var fertileWindowEnd = ovulationDay.AddDays(1);
+
+        var today = _dateTimeService.Today;
+        if (today > fertileWindowEnd)
+            return;
+        else if (today == fertileWindowEnd)
+        {
+            FertileWindowText = "Today should be the last day with the highest chance for pregnancy.";
+        }
+        else if (today == fertileWindowEnd.AddDays(-1))
+        {
+            FertileWindowText = "Tomorrow should be the last day with the highest chances for pregnancy.";
+            FertileWindowDateText = $"Ends:{Environment.NewLine}{fertileWindowEnd:D}";
+        }
+        else if (today >= fertileWindowStart)
+        {
+            var daysRemaining = (fertileWindowEnd - today).Days;
+            FertileWindowText = $"Highest chances for pregnancy should be ending soon. Last day should be in {daysRemaining} days.";
+            FertileWindowDateText = $"Ends:{Environment.NewLine}{fertileWindowEnd:D}";
+        }
+        else
+        {
+            var daysUntil = (fertileWindowStart - today).Days;
+            var dayText = daysUntil > 1 ? "days" : "day";
+            FertileWindowText = $"Highest chances for pregnancy should start in {daysUntil} {dayText}.";
+            FertileWindowDateText = $"{fertileWindowStart:D}{Environment.NewLine}      thru{Environment.NewLine}{fertileWindowEnd:D}";
+        }
+
     }
 
     private void UpdatePeriodEndText(DateTime cycleStart)

--- a/PeriodTracker/Views/MainPage.xaml
+++ b/PeriodTracker/Views/MainPage.xaml
@@ -72,7 +72,6 @@
                             Text="{Binding FertileWindowDateText}"
                             IsVisible="{Binding FertileWindowText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
                             HorizontalOptions="End"
-                            TextAlignment="End"
                             Margin="0,0,10,0"
                             />
                     </VerticalStackLayout>

--- a/PeriodTracker/Views/MainPage.xaml
+++ b/PeriodTracker/Views/MainPage.xaml
@@ -51,13 +51,28 @@
                         >
                         <Label
                             Text="{Binding PeriodEndText}"
-                            IsVisible="{Binding PeriodEndText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
                             HorizontalOptions="Start"
                             />
                         <Label
                             Text="{Binding PeriodEndDateText}"
                             IsVisible="{Binding PeriodEndText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
                             HorizontalOptions="End"
+                            Margin="0,0,10,0"
+                            />
+                    </VerticalStackLayout>
+
+                    <VerticalStackLayout
+                        IsVisible="{Binding FertileWindowText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
+                        >
+                        <Label
+                            Text="{Binding FertileWindowText}"
+                            HorizontalOptions="Start"
+                            />
+                        <Label
+                            Text="{Binding FertileWindowDateText}"
+                            IsVisible="{Binding FertileWindowText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
+                            HorizontalOptions="End"
+                            TextAlignment="End"
                             Margin="0,0,10,0"
                             />
                     </VerticalStackLayout>

--- a/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
+++ b/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
@@ -34,6 +34,64 @@ public class MainViewModelTests: BaseTest, IClassFixture<TemporaryDirectoryFixtu
     }
 
     [Theory]
+    [InlineData("2026-04-16", "2026-04-16", "2026-04-27", "2026-05-01", "Highest chances for pregnancy should start in 11 days.", "{start}{NL}      thru{NL}{end}")]
+    [InlineData("2026-04-16", "2026-04-26", "2026-04-27", "2026-05-01", "Highest chances for pregnancy should start in 1 day.", "{start}{NL}      thru{NL}{end}")]
+    [InlineData("2026-04-16", "2026-04-27", "", "2026-05-01", "Highest chances for pregnancy should be ending soon. Last day should be in 4 days.", "Ends:{NL}{end}")]
+    [InlineData("2026-04-16", "2026-04-30", "", "2026-05-01", "Tomorrow should be the last day with the highest chances for pregnancy.", "Ends:{NL}{end}")]
+    [InlineData("2026-04-16", "2026-05-01", "", "", "Today should be the last day with the highest chance for pregnancy.", "")]
+    [InlineData("2026-04-16", "2026-05-02", "", "", "", "")]
+    public async Task LoadAsync_CalculateFertialeWindowCorrectly(
+        string inpMostRecentCycleStartStr,
+        string inpTodayStr,
+        string expFertileWindowDateStartText,
+        string expFertileWindowDateEndText,
+        string expFertileWindowText,
+        string expFertileWindowDateTextTemplate
+    )
+    {
+        var today = DateTime.Parse(inpTodayStr);
+
+        var testTempDir = _tempDir.CreateTestCaseDirectory(inpTodayStr);
+        var seedData = new SeedData {
+            Cycles = new List<Cycle> {
+                new Cycle { StartDate = DateTime.Parse(inpMostRecentCycleStartStr) }
+            }
+        };
+        await SetupDatabase(testTempDir, seedData);
+
+        SetupMocks(testTempDir, today);
+
+        _mockUpdateService.Setup(s => s.GetShouldCheckForUpdates())
+            .ReturnsAsync(false);
+
+        var actor = new MainViewModel(
+            _mockDbContextProvider.Object,
+            _mockDateTimeService.Object,
+            _mockUpdateServiceProvider.Object,
+            _mockAppInfo.Object,
+            _mockAlertService.Object);
+
+        await actor.LoadAsync();
+
+        expFertileWindowDateStartText = string.IsNullOrEmpty(expFertileWindowDateStartText)
+            ? string.Empty
+            : DateTime.Parse(expFertileWindowDateStartText).ToString("D");
+
+        expFertileWindowDateEndText = string.IsNullOrEmpty(expFertileWindowDateEndText)
+            ? string.Empty
+            : DateTime.Parse(expFertileWindowDateEndText).ToString("D");
+
+        var expFertileWindowDateText = expFertileWindowDateTextTemplate
+            .Replace("{start}", expFertileWindowDateStartText)
+            .Replace("{end}", expFertileWindowDateEndText)
+            .Replace("{NL}", Environment.NewLine);
+
+
+        Assert.Equal(expFertileWindowText, actor.FertileWindowText);
+        Assert.Equal(expFertileWindowDateText, actor.FertileWindowDateText);
+    }
+
+    [Theory]
     [InlineData("2026-04-16", "2026-04-16", "2026-04-22", "Last day of your period should be in 6 days:")]
     [InlineData("2026-04-16", "2026-04-17", "2026-04-22", "Last day of your period should be in 5 days:")]
     [InlineData("2026-04-16", "2026-04-21", "2026-04-22", "Last day of your period should be in 1 day:")]

--- a/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
+++ b/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
@@ -94,7 +94,7 @@ public class MainViewModelTests: BaseTest, IClassFixture<TemporaryDirectoryFixtu
     [Theory]
     [InlineData("2026-04-16", "2026-04-16", "2026-04-22", "Last day of your period should be in 6 days:")]
     [InlineData("2026-04-16", "2026-04-17", "2026-04-22", "Last day of your period should be in 5 days:")]
-    [InlineData("2026-04-16", "2026-04-21", "2026-04-22", "Last day of your period should be in 1 day:")]
+    [InlineData("2026-04-16", "2026-04-21", "2026-04-22", "Tomorrow should be the last day of your period.")]
     [InlineData("2026-04-16", "2026-04-22", "", "Today should be the last day of your period.")]
     [InlineData("2026-04-16", "2026-04-23", "", "")]
     public async Task LoadAsync_CalculatePeriodEndCorrectly(

--- a/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
+++ b/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
@@ -94,7 +94,7 @@ public class MainViewModelTests: BaseTest, IClassFixture<TemporaryDirectoryFixtu
     [Theory]
     [InlineData("2026-04-16", "2026-04-16", "2026-04-22", "Last day of your period should be in 6 days:")]
     [InlineData("2026-04-16", "2026-04-17", "2026-04-22", "Last day of your period should be in 5 days:")]
-    [InlineData("2026-04-16", "2026-04-21", "2026-04-22", "Tomorrow should be the last day of your period.")]
+    [InlineData("2026-04-16", "2026-04-21", "", "Tomorrow should be the last day of your period.")]
     [InlineData("2026-04-16", "2026-04-22", "", "Today should be the last day of your period.")]
     [InlineData("2026-04-16", "2026-04-23", "", "")]
     public async Task LoadAsync_CalculatePeriodEndCorrectly(


### PR DESCRIPTION
- Added functionality to display the fertile window range in the main view.
- Updated wording use for day before last day of period. This is to be consistent with wording used for fertile window range.

closes #33 
