### PR TITLE
feat: Change "Your next period is..." text to vary by days left

### DIFF
--- a/PeriodTracker/ViewModels/MainViewModel.cs
+++ b/PeriodTracker/ViewModels/MainViewModel.cs
@@ -46,6 +46,8 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
 
     [ObservableProperty]
     private string nextCycleStartDateText = string.Empty;
+    [ObservableProperty]
+    private string nextCycleStartText = string.Empty;
 
     [ObservableProperty]
     private string periodEndDateText = string.Empty;
@@ -66,8 +68,6 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
             IsBusy = true;
             IsCycleStartOverdue = false;
 
-            var today = _dateTimeService.Today;
-
             using var db = await _dbContextProvider.GetContext();
             var mostRecentCycleStart = await
                 (from c in db.Cycles
@@ -78,22 +78,9 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
 
             if (mostRecentCycleStart.Equals(default)) return;
 
-            var daysEllapsed = (today - mostRecentCycleStart).Days;
-            var daysUntilNext = _defaultCycleLengthDays - daysEllapsed;
-
-            DaysUntilNextCycleText = daysUntilNext switch {
-                0 when mostRecentCycleStart == today => $"{_defaultCycleLengthDays}",
-                >= 0 => $"{daysUntilNext}",
-                _ => "0"
-            };
-
-            IsCycleStartOverdue = daysUntilNext < 0;
-            NextCycleStartDateText = mostRecentCycleStart
-                .AddDays(_defaultCycleLengthDays)
-                .ToString("D");
-
-            UpdateFertileWindowText(mostRecentCycleStart);
             UpdatePeriodEndText(mostRecentCycleStart);
+            UpdateFertileWindowText(mostRecentCycleStart);
+            UpdateNextPeriodStartText(mostRecentCycleStart);
 
             await CheckForUpdates();
         }
@@ -183,7 +170,6 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
         PeriodEndDateText = daysRemaining > 1 ? periodEndDate.ToString("D") : string.Empty;
         PeriodEndText = daysRemaining switch
         {
-            // > 0 => $"The last day of your period should be {periodEndDate:D} (in {daysRemaining} days).",
             > 1 => $"Last day of your period should be in {daysRemaining} days:",
             1 => $"Tomorrow should be the last day of your period.",
             0 => "Today should be the last day of your period.",
@@ -191,4 +177,33 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
         };
     }
 
+    private void UpdateNextPeriodStartText(DateTime cycleStart)
+    {
+        var today = _dateTimeService.Today;
+        var daysEllapsed = (today - cycleStart).Days;
+        var daysUntilNext = _defaultCycleLengthDays - daysEllapsed;
+
+        DaysUntilNextCycleText = daysUntilNext switch {
+            0 when cycleStart == today => $"{_defaultCycleLengthDays}",
+            >= 0 => $"{daysUntilNext}",
+            _ => "0"
+        };
+
+        IsCycleStartOverdue = daysUntilNext < 0;
+
+        NextCycleStartText = daysUntilNext switch
+        {
+            > 1 => $"Your next period should start on:",
+            1 => $"Your next period should start tomorrow.",
+            0 => $"Your next period should start today.",
+            -1 => $"Your next period should have started yesterday.",
+            < -1 => $"Your next period should have started {-daysUntilNext} days ago."
+        };
+        NextCycleStartDateText = daysUntilNext switch
+        {
+            var d when d > 1 || d < -1 =>
+                cycleStart.AddDays(_defaultCycleLengthDays).ToString("D"),
+            _ => string.Empty
+        };
+    }
 }

--- a/PeriodTracker/Views/MainPage.xaml
+++ b/PeriodTracker/Views/MainPage.xaml
@@ -35,7 +35,7 @@
                     >
                     <Label
                         Text="{Binding DaysUntilNextCycleText}"
-                        IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+                        IsVisible="{Binding IsCycleStartOverdue, Converter={StaticResource InvertedBoolConverter}}"
                         Style="{StaticResource SubHeadline}"
                         SemanticProperties.HeadingLevel="Level2"/>
 
@@ -78,13 +78,12 @@
 
                     <VerticalStackLayout>
                         <Label
-                            Text="Your next period is expected to start on:"
-                            IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+                            Text="{Binding NextCycleStartText}"
                             HorizontalOptions="Start"
                             />
                         <Label
                             Text="{Binding NextCycleStartDateText}"
-                            IsVisible="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+                            IsVisible="{Binding NextCycleStartDateText, Converter={StaticResource StringNotNullOrEmptyToBoolConverter}}"
                             HorizontalOptions="End"
                             Margin="0,0,10,0"
                             />

--- a/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
+++ b/PeriodTrackerTests/Tests/MainViewModelTests/MainViewModelTests.cs
@@ -136,17 +136,20 @@ public class MainViewModelTests: BaseTest, IClassFixture<TemporaryDirectoryFixtu
     }
 
     [Theory]
-    [InlineData("2026-04-16", "2026-04-16", "29", false)]
-    [InlineData("2026-04-16", "2026-04-29", "16", false)]
-    [InlineData("2026-04-16", "2026-05-13", "2", false)]
-    [InlineData("2026-04-16", "2026-05-14", "1", false)]
-    [InlineData("2026-04-16", "2026-05-15", "0", false)]
-    [InlineData("2026-04-16", "2026-05-20", "0", true)]
+    [InlineData("2026-04-16", "2026-04-16", "29", false, "2026-05-15", "Your next period should start on:")]
+    [InlineData("2026-04-16", "2026-04-29", "16", false, "2026-05-15", "Your next period should start on:")]
+    [InlineData("2026-04-16", "2026-05-13", "2", false, "2026-05-15", "Your next period should start on:")]
+    [InlineData("2026-04-16", "2026-05-14", "1", false, "", "Your next period should start tomorrow.")]
+    [InlineData("2026-04-16", "2026-05-15", "0", false, "", "Your next period should start today.")]
+    [InlineData("2026-04-16", "2026-05-16", "0", true, "", "Your next period should have started yesterday.")]
+    [InlineData("2026-04-16", "2026-05-20", "0", true, "2026-05-15", "Your next period should have started 5 days ago.")]
     public async Task LoadAsync_CalculatesDaysUntilNextCycleCorrectly(
         string inpMostRecentCycleStartStr,
         string inpTodayStr,
         string expDaysUntilNextCycleText,
-        bool expIsCycleStartOverdue)
+        bool expIsCycleStartOverdue,
+        string expNextCycleStartDateText,
+        string expNextCycleStartText)
     {
         var today = DateTime.Parse(inpTodayStr);
         var mockDateTimeService = new Mock<IDateTimeService>();
@@ -182,7 +185,13 @@ public class MainViewModelTests: BaseTest, IClassFixture<TemporaryDirectoryFixtu
 
         await actor.LoadAsync();
 
+        expNextCycleStartDateText = string.IsNullOrEmpty(expNextCycleStartDateText)
+            ? string.Empty
+            : DateTime.Parse(expNextCycleStartDateText).ToString("D");
+
         Assert.Equal(expDaysUntilNextCycleText, actor.DaysUntilNextCycleText);
         Assert.Equal(expIsCycleStartOverdue, actor.IsCycleStartOverdue);
+        Assert.Equal(expNextCycleStartDateText, actor.NextCycleStartDateText);
+        Assert.Equal(expNextCycleStartText, actor.NextCycleStartText);
     }
 }


### PR DESCRIPTION
Updated the "Your next period is..." text to vary based on how many days are left until the next cycle starts, and whether the cycle start is overdue.

closes #37