### PR TITLE
task: change default delay to 1 second

### DIFF
--- a/PeriodTracker/App.xaml.cs
+++ b/PeriodTracker/App.xaml.cs
@@ -8,4 +8,14 @@ public partial class App : Application
 
 		MainPage = new AppShell();
 	}
+
+    /// <summary>
+    /// This is used to create a delay that can be awaited without blocking the
+    /// UI thread. This is useful for simulating a loading state or giving the
+    /// user feedback that an action is being processed.
+    /// </summary>
+    public static Task Delay(int milliseconds = 1000)
+    {
+        return Task.Delay(milliseconds);
+    }
 }

--- a/PeriodTracker/ViewModels/CycleEditViewModel.cs
+++ b/PeriodTracker/ViewModels/CycleEditViewModel.cs
@@ -30,7 +30,7 @@ public partial class CycleEditViewModel : ViewModelBase
     private DateTime selectedStartDate = DateTime.Today;
 
     public async Task<bool> Save() {
-        var delayTask = Task.Delay(TimeSpan.FromSeconds(2));
+        var delayTask = App.Delay();
 
         try{
             IsBusy = true;

--- a/PeriodTracker/ViewModels/HistoryViewModel.cs
+++ b/PeriodTracker/ViewModels/HistoryViewModel.cs
@@ -31,7 +31,7 @@ public class HistoryViewModel : ViewModelBase, IEventBusListener
 
         if (!confirmDelete) return;
 
-        var delayTask = Task.Delay(TimeSpan.FromSeconds(2));
+        var delayTask = App.Delay();
         try{
             IsBusy = true;
 
@@ -60,7 +60,7 @@ public class HistoryViewModel : ViewModelBase, IEventBusListener
     public async Task LoadAsync(){
         if (!dataRefreshRequired) return;
 
-        var delayTask = Task.Delay(TimeSpan.FromSeconds(2));
+        var delayTask = App.Delay();
         try{
             IsBusy = true;
 

--- a/PeriodTracker/ViewModels/MainViewModel.cs
+++ b/PeriodTracker/ViewModels/MainViewModel.cs
@@ -63,7 +63,7 @@ public partial class MainViewModel : ViewModelBase, IEventBusListener
     public async Task LoadAsync(){
         if (!dataRefreshRequired) return;
 
-        var delayTask = Task.Delay(TimeSpan.FromSeconds(2));
+        var delayTask = App.Delay();
         try{
             IsBusy = true;
             IsCycleStartOverdue = false;


### PR DESCRIPTION
2 seconds was just to long. 1 second is enough to simulate "doing work" and it not slow down the user experience too much.

closes #7 