### PR TITLE
chore: resolve obsolete testcase compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ publish/
 PeriodTracker/commit_hash.txt
 PeriodTracker.keystore
 **/*.user
+**/*.csproj.lscache
 

--- a/PeriodTrackerTests/GlobalUsings.cs
+++ b/PeriodTrackerTests/GlobalUsings.cs
@@ -1,1 +1,4 @@
+global using System;
+global using System.Collections;
+global using System.Collections.Generic;
 global using Xunit;

--- a/PeriodTrackerTests/SeedData.cs
+++ b/PeriodTrackerTests/SeedData.cs
@@ -3,7 +3,15 @@ using PeriodTracker;
 
 namespace PeriodTrackerTests;
 
-public class SeedData
+public interface ISeedDataProvider
 {
-    public required List<Cycle> Cycles {get; init;} = new();
+    SeedData GetSeedData();
+}
+
+public class SeedData: ISeedDataProvider
+{
+    public List<AppState> AppStates {get; init;} = new();
+    public List<Cycle> Cycles {get; init;} = new();
+
+    public SeedData GetSeedData() => this;
 }

--- a/PeriodTrackerTests/Tests/AppDbContextTests/AddCycle.cs
+++ b/PeriodTrackerTests/Tests/AppDbContextTests/AddCycle.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using PeriodTracker;
 
 namespace PeriodTrackerTests;
@@ -5,108 +6,138 @@ namespace PeriodTrackerTests;
 public partial class AppDbContextTests
 {
 
-    [Theory, MemberData(nameof(AddCycleTestsData))]
-    public async Task AddCycleTests(TestCase test){
+    [Theory, ClassData(typeof(AddCycleTestsData))]
+    public async Task AddCycleTests(TestCase<AddCycleTestsData.TestParameters> test){
         var testTempDir = _tempDir.CreateTestCaseDirectory(test.Name);
 
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
 
-        var inp = ((Cycle[]?)test.Inputs["cycles"])!;
+        var inp = test.Parameters.Inputs.Cycles;
 
-        var actInsertedResults = new bool[inp.Length];
-        for(var i =0; i < inp.Length; i++)
+        var actInsertedResults = new bool[inp.Count];
+        for(var i =0; i < inp.Count; i++)
             actInsertedResults[i] = await db.AddCycle(inp[i]);
 
-        var actInserted = (from c in db.Cycles select c).ToArray();
+        var actInserted = await (from c in db.Cycles select c).ToListAsync();
 
-        var expInserted = (Cycle[]?)test.Expected["cycles"];
-        var expInsertedResults = (bool[]?)test.Expected["insert results"];
+        var expInserted = test.Parameters.Expected.Cycles;
+        var expInsertedResults = test.Parameters.Expected.InsertResults;
 
         Assert.Equal(expInsertedResults, actInsertedResults);
         AssertCycles(expInserted, actInserted);
     }
 
-    public static IEnumerable<object[]> AddCycleTestsData =>
-        new []{
-            new TestCase("Add single")
-            .WithInput("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        }})
-            .WithExpected("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        }})
-            .WithExpected("insert results", new[]{true}),
+    public class AddCycleTestsData: IEnumerable<object[]>
+    {
+        public record TestParameters(Inputs Inputs, ExpectedResults Expected);
+        public static IEnumerable<object[]> TestCases()
+        {
+            yield return new[] {
+                new TestCase<TestParameters>("Add single",
+                new TestParameters(
+                    new Inputs{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            }}},
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            }},
+                        InsertResults = new List<bool>{true}
+                    }))};
 
-            new TestCase("Add many")
-            .WithInput("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        },
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-12-01")
-                    }
-                        })
-            .WithExpected("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        },
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-12-01")
-                    }
-                        })
-            .WithExpected("insert results", new[]{true, true}),
+            yield return new[] {
+                new TestCase<TestParameters>("Add many",
+                new TestParameters(
+                    new Inputs{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            },
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            }}},
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            },
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            }},
+                        InsertResults = new List<bool>{true, true}
+                    }))};
 
-            new TestCase("Add many - inverted")
-            .WithInput("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-12-01")
-                        },
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        }
-                    })
-            .WithExpected("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        },
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-12-01")
-                    }
-                        })
-            .WithExpected("insert results", new[]{true, true}),
+            yield return new[] {
+                new TestCase<TestParameters>("Add many - inverted",
+                new TestParameters(
+                    new Inputs{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            },
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            }}},
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            },
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            }},
+                        InsertResults = new List<bool>{true, true}
+                    }))};
 
-            new TestCase("Add many with same date")
-            .WithInput("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        },
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01")
-                    }
-                        })
-            .WithExpected("cycles", new []{
-                    new Cycle{
-                        RecordedDate = DateTime.Today,
-                        StartDate = DateTime.Parse("2023-11-01"),
-                        },
-                        })
-            .WithExpected("insert results", new[]{true, false}),
-
+            yield return new[] {
+                new TestCase<TestParameters>("Add many with same date",
+                new TestParameters(
+                    new Inputs{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            },
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            }}},
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            }},
+                        InsertResults = new List<bool>{true, false}
+                    }))};
         }
-        .Select(tc => new object[] {tc});
 
+        public IEnumerator<object[]> GetEnumerator() => TestCases().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public class ExpectedResults
+        {
+            public List<bool> InsertResults {get; init;} = new();
+            public List<Cycle> Cycles {get; init;} = new();
+        }
+
+        public class Inputs
+        {
+            public List<Cycle> Cycles {get; init;} = new();
+        }
+    }
 }

--- a/PeriodTrackerTests/Tests/AppDbContextTests/AllAppStatePropertiesExist.cs
+++ b/PeriodTrackerTests/Tests/AppDbContextTests/AllAppStatePropertiesExist.cs
@@ -19,7 +19,7 @@ public partial class AppDbContextTests
             object value = prop switch {
                 AppStateProperty.NotifyUpdateAvailableInterval => await db.GetAppStateValue(prop, Convert.ToInt32),
                 AppStateProperty.NotifyUpdateAvailableNextDate => await db.GetAppStateValue(prop, Convert.ToDateTime),
-                _ => throw new NotImplementedException($"App state property '{prop}' not handled.")
+                _ => throw new NotImplementedException($"App state property '{prop}' not expected.")
             };
         }
 

--- a/PeriodTrackerTests/Tests/AppDbContextTests/DeleteCycle.cs
+++ b/PeriodTrackerTests/Tests/AppDbContextTests/DeleteCycle.cs
@@ -1,98 +1,130 @@
-﻿using PeriodTracker;
+﻿using Microsoft.EntityFrameworkCore;
+using PeriodTracker;
 
 namespace PeriodTrackerTests;
 
 public partial class AppDbContextTests
 {
 
-    [Theory, MemberData(nameof(DeleteCycleTestsData))]
-    public async Task DeleteCycleTests(TestCase test){
+    [Theory, ClassData(typeof(DeleteCycleTestsData))]
+    public async Task DeleteCycleTests(TestCase<DeleteCycleTestsData.TestParameters> test){
         var testTempDir = _tempDir.CreateTestCaseDirectory(test.Name);
 
-        await SetupDatabase(testTempDir, test.Setups);
+        await SetupDatabase(testTempDir, test.Parameters.Inputs);
 
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
 
-        var toDelete = ((Cycle?)test.Inputs["cycle"])!;
+        var toDelete = test.Parameters.Inputs.Cycle;
 
         var actDeleteResult = await db.DeleteCycle(toDelete);
-        var actCycles = (from c in db.Cycles select c).ToArray();
+        var actCycles = await (from c in db.Cycles select c).ToListAsync();
 
-        var expCycles = (Cycle[]?)test.Expected["cycles"];
-        var expDeleteResult = (bool?)test.Expected["delete result"];
+        var expCycles = test.Parameters.Expected.Cycles;
+        var expDeleteResult = test.Parameters.Expected.DeleteResult;
 
         Assert.Equal(expDeleteResult, actDeleteResult);
         AssertCycles(expCycles, actCycles);
     }
 
-    public static IEnumerable<object[]> DeleteCycleTestsData =>
-        new []{
-            new TestCase("Target exists")
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"Cycle", new[]{
-                        new Cycle{
-                            RecordedDate = DateTime.Today,
-                            StartDate = DateTime.Parse("2023-11-01"),
-                            },
-                        new Cycle{
+    public class DeleteCycleTestsData: IEnumerable<object[]>
+    {
+        public record TestParameters(Inputs Inputs, ExpectedResults Expected);
+
+        public static IEnumerable<object[]> TestCases()
+        {
+            yield return new object[]{
+                new TestCase<TestParameters>("Target exists",
+                new TestParameters(
+                    new Inputs{
+                        Cycle = new Cycle {
                             RecordedDate = DateTime.Today,
                             StartDate = DateTime.Parse("2023-12-01")
-                        }
-                    }},
-                })
-            .WithInput("cycle", new Cycle {
-                RecordedDate = DateTime.Today,
-                StartDate = DateTime.Parse("2023-12-01")
-            })
-            .WithExpected("cycles", new[]{
-                        new Cycle{
-                            RecordedDate = DateTime.Today,
-                            StartDate = DateTime.Parse("2023-11-01"),
+                        },
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
                             },
-            })
-            .WithExpected("delete result", true),
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            }
+                        }},
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
+                            }},
+                        DeleteResult = true
+                    }))};
 
-            new TestCase("Target does not exist")
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"Cycle", new[]{
-                        new Cycle{
+            yield return new object[]{
+                new TestCase<TestParameters>("Target does not exist",
+                new TestParameters(
+                    new Inputs{
+                        Cycle = new Cycle {
                             RecordedDate = DateTime.Today,
-                            StartDate = DateTime.Parse("2023-11-01"),
+                            StartDate = DateTime.Parse("2023-10-02")
+                        },
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
                             },
-                        new Cycle{
-                            RecordedDate = DateTime.Today,
-                            StartDate = DateTime.Parse("2023-12-01")
-                        }
-                    }},
-                })
-            .WithInput("cycle", new Cycle {
-                RecordedDate = DateTime.Today,
-                StartDate = DateTime.Parse("2023-10-02")
-            })
-            .WithExpected("cycles", new []{
-                        new Cycle{
-                            RecordedDate = DateTime.Today,
-                            StartDate = DateTime.Parse("2023-11-01"),
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            }
+                        }},
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-11-01"),
                             },
-                        new Cycle{
+                            new (){
+                                RecordedDate = DateTime.Today,
+                                StartDate = DateTime.Parse("2023-12-01"),
+                            }
+                        },
+                        DeleteResult = false
+                    }))};
+
+            yield return new object[]{
+                new TestCase<TestParameters>("Cycles are empty",
+                new TestParameters(
+                    new Inputs{
+                        Cycle = new Cycle {
                             RecordedDate = DateTime.Today,
-                            StartDate = DateTime.Parse("2023-12-01")
-                        }
-            })
-            .WithExpected("delete result", false),
+                            StartDate = DateTime.Parse("2023-10-02")
+                        },
+                        Cycles = new List<Cycle>()
+                    },
+                    new ExpectedResults{
+                        Cycles = new List<Cycle>(),
+                        DeleteResult = false
+                    }))};
 
-            new TestCase("Cycles are empty")
-            .WithInput("cycle", new Cycle {
-                RecordedDate = DateTime.Today,
-                StartDate = DateTime.Parse("2023-10-02")
-            })
-            .WithExpected("cycles", new Cycle[]{})
-            .WithExpected("delete result", false)
+        }
 
-        }.Select(tc => new object[]{tc});
+        public IEnumerator<object[]> GetEnumerator() => TestCases().GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+        public class ExpectedResults
+        {
+            public List<Cycle> Cycles { get; set; } = new();
+            public bool DeleteResult { get; set; }
+        }
+
+        public class Inputs: ISeedDataProvider
+        {
+            public Cycle Cycle { get; set; } = new();
+            public List<Cycle> Cycles { get; set; } = new();
+
+            public SeedData GetSeedData() => new SeedData{
+                Cycles = Cycles
+            };
+        }
+    }
 }

--- a/PeriodTrackerTests/Tests/AppDbContextTests/GetCycleHistory.cs
+++ b/PeriodTrackerTests/Tests/AppDbContextTests/GetCycleHistory.cs
@@ -10,14 +10,26 @@ public partial class AppDbContextTests
     {
         var testTempDir = _tempDir.CreateTestCaseDirectory(t.Name);
 
-        await SetupDatabase(testTempDir, t.Parameters.Inputs.GetSeedData());
+        await SetupDatabase(testTempDir, t.Parameters.Inputs);
 
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
 
         var act = await db.GetCycleHistory();
-        var exp = t.Parameters.Expected.Cycles;
+        var exp = t.Parameters.Expected.Cycles.OrderByDescending(c => c.StartDate).ToList();
 
-        AssertCyclesHistory(exp, act);
+        Assert.Equal(exp.Count, act.Count);
+
+        var zipExpAct = exp.Zip(act);
+        Assert.All(
+            zipExpAct,
+            expAct =>
+            {
+                var (exp, act) = expAct;
+                Assert.Equal(exp.StartDate, act.StartDate);
+                Assert.Equal(exp.RecordedDate, act.RecordedDate);
+                Assert.Equal(exp.CycleLengthDays, act.CycleLengthDays);
+            }
+        );
     }
 
     public class GetCycleHistoryTestData : IEnumerable<object[]>
@@ -123,7 +135,7 @@ public partial class AppDbContextTests
             public List<CycleHistory> Cycles { get; set; } = [];
         }
 
-        public class Inputs
+        public class Inputs: ISeedDataProvider
         {
             public List<Cycle> Cycles { get; set; } = [];
 

--- a/PeriodTrackerTests/Tests/AppDbContextTests/_base.cs
+++ b/PeriodTrackerTests/Tests/AppDbContextTests/_base.cs
@@ -13,37 +13,20 @@ public partial class AppDbContextTests : BaseTest, IClassFixture<TemporaryDirect
         _tempDir = tempDirFixture;
     }
 
-    private void AssertCycles(Cycle[]? expected, Cycle[]? actual)
+    private void AssertCycles(List<Cycle> expected, List<Cycle> actual)
     {
-        if (expected is null && actual is null) return;
-        if (expected is null || actual is null)
-            Assert.Fail("Either expected or actual are null");
-
-        Assert.Equal(expected.Length, actual.Length);
-        Assert.All(
-            expected,
-            exp =>
-            {
-                var act = actual.First(a => a.Equals(exp));
-                Assert.Equal(exp.RecordedDate, act.RecordedDate);
-            }
-        );
-    }
-
-    private void AssertCyclesHistory(List<CycleHistory> expected, List<CycleHistory> actual)
-    {
-        if (expected is null && actual is null) return;
-        if (expected is null || actual is null)
-            Assert.Fail("Either expected or actual are null");
-
         Assert.Equal(expected.Count, actual.Count);
+
+        expected = expected.OrderBy(c => c.StartDate).ToList();
+        actual = actual.OrderBy(c => c.StartDate).ToList();
+
+        var zipExpAct = expected.Zip(actual);
         Assert.All(
-            expected,
-            exp =>
+            zipExpAct,
+            expAct =>
             {
-                var act = actual.First(a => a.StartDate == exp.StartDate);
+                var (exp, act) = expAct;
                 Assert.Equal(exp.RecordedDate, act.RecordedDate);
-                Assert.Equal(exp.CycleLengthDays, act.CycleLengthDays);
             }
         );
     }

--- a/PeriodTrackerTests/Tests/BaseTest.cs
+++ b/PeriodTrackerTests/Tests/BaseTest.cs
@@ -5,42 +5,37 @@ namespace PeriodTrackerTests;
 
 public class BaseTest
 {
-
-    protected static IEnumerable<object[]> BundleTestCases(params TestCase[] testCases) =>
-        testCases.Select(tc => new object[]{tc});
-
     protected DbContextOptions<AppDbContext> CreateDbContextOptions(DirectoryInfo testTempDir) =>
         new DbContextOptionsBuilder<AppDbContext>()
             .UseSqlite($"Data Source={Path.Combine(testTempDir.FullName, "_.db")}")
             .Options;
 
-    protected async Task SetupDatabase(DirectoryInfo testTempDir, Dictionary<string, object?> testSetups){
-        if (!testSetups.TryGetValue("database", out var maybeTables)) return;
-
-        var tables = maybeTables as Dictionary<string, object[]>;
-
-        using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
-
-        if (tables!.TryGetValue("Cycle", out var cyclesData))
-            foreach(var cycle in (Cycle[])cyclesData)
-                db.Cycles.Add(cycle);
-
-        if (tables!.TryGetValue("AppState", out var appStateData))
-            foreach(object[] row in appStateData){
-                var dbItem = db.AppState.Where(r => r.AppStatePropertyId == (AppStateProperty)row[0]).First();
-                dbItem.Value = row[1].ToString()!;
-            }
-
-        await db.SaveChangesAsync();
-    }
-
-    protected async Task SetupDatabase(DirectoryInfo testTempDir, SeedData seedData)
+    protected async Task SetupDatabase(DirectoryInfo testTempDir, ISeedDataProvider seedDataProvider)
     {
+        var seedData = seedDataProvider.GetSeedData();
+
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
 
-        // AppState table is seeded by database initialization
+        if (seedData.AppStates.Any())
+        {
+            // For AppStates seeding, we need to remove any existing entries
+            // that we are going to seed.
+            foreach(var item in seedData.AppStates)
+            {
+                await (
+                    from a in db.AppState
+                    where a.AppStatePropertyId == item.AppStatePropertyId
+                    select a
+                ).ExecuteDeleteAsync();
 
-        db.Cycles.AddRange(seedData.Cycles);
+                db.AppState.Add(item);
+            }
+        }
+
+        if (seedData.Cycles.Any())
+        {
+            db.Cycles.AddRange(seedData.Cycles);
+        }
 
         await db.SaveChangesAsync();
     }

--- a/PeriodTrackerTests/Tests/ImportExportServiceTests/ImportExportServiceTests.cs
+++ b/PeriodTrackerTests/Tests/ImportExportServiceTests/ImportExportServiceTests.cs
@@ -18,7 +18,7 @@ public partial class ImportExportServiceTests: BaseTest, IClassFixture<Temporary
     {
         var testTempDir = _tempDir.CreateTestCaseDirectory(t.Name);
 
-        await SetupDatabase(testTempDir, t.Parameters.Inputs.GetSeedData());
+        await SetupDatabase(testTempDir, t.Parameters.Inputs);
 
         var actor = new ImportExportService();
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
@@ -33,7 +33,7 @@ public partial class ImportExportServiceTests: BaseTest, IClassFixture<Temporary
     {
         var testTempDir = _tempDir.CreateTestCaseDirectory(t.Name);
 
-        await SetupDatabase(testTempDir, t.Parameters.Inputs.GetSeedData());
+        await SetupDatabase(testTempDir, t.Parameters.Inputs);
 
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
 

--- a/PeriodTrackerTests/Tests/ImportExportServiceTests/TestData/GetDataForExport.cs
+++ b/PeriodTrackerTests/Tests/ImportExportServiceTests/TestData/GetDataForExport.cs
@@ -114,7 +114,7 @@ public partial class ImportExportServiceTests
             public required string Payload {get; init;}
         }
 
-        public class Inputs
+        public class Inputs: ISeedDataProvider
         {
             public required Version AppVersion {get; init;}
             public required List<Cycle> Cycles {get; init;}

--- a/PeriodTrackerTests/Tests/ImportExportServiceTests/TestData/ImportData.cs
+++ b/PeriodTrackerTests/Tests/ImportExportServiceTests/TestData/ImportData.cs
@@ -413,7 +413,7 @@ public partial class ImportExportServiceTests
             public Exception? Exception {get; init;} = null;
         }
 
-        public class Inputs
+        public class Inputs: ISeedDataProvider
         {
             public required Version AppVersion {get; init;}
             public required string Payload {get; init;}

--- a/PeriodTrackerTests/Tests/UpdateServiceTests/GetLatestVersionTests.cs
+++ b/PeriodTrackerTests/Tests/UpdateServiceTests/GetLatestVersionTests.cs
@@ -8,92 +8,136 @@ namespace PeriodTrackerTests;
 public partial class UpdateServiceTests
 {
 
-    [Theory, MemberData(nameof(GetLatestVersionTestsData))]
-    public async Task GetLatestVersionTests(TestCase test){
+    [Theory, ClassData(typeof(GetLatestVersionTestsData))]
+    public async Task GetLatestVersionTests(TestCase<GetLatestVersionTestsData.TestParameters> test){
 
-        SetupHttpClientFactoryMock(test.Setups["httpclientfactory"]!);
+        SetupHttpClientFactoryMock(test.Parameters.Inputs.HttpResponseMessage);
 
         using var actor = new UpdateService(_httpClientFactoryMock.Object, _dbContextProviderMock.Object);
         var actVersion = await actor.GetLatestVersion();
 
-        var expVersion = (Version?)test.Expected["version"];
+        var expVersion = test.Parameters.Expected.Version;
 
         Assert.Equal(expVersion, actVersion);
     }
 
-    private void SetupHttpClientFactoryMock(object httpClientFactorySetup){
-        var setupData = (httpClientFactorySetup as Dictionary<string, object>)!;
-
+    private void SetupHttpClientFactoryMock(HttpResponseMessage setupResponseMessage){
         // ref: https://stackoverflow.com/a/44028625
         var mh = new Mock<HttpMessageHandler>();
         mh.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage{
-                StatusCode = (HttpStatusCode)setupData["status code"],
-                Content = (StringContent)setupData["content"]
-            });
+            .ReturnsAsync(setupResponseMessage);
 
-        _httpClientFactoryMock.Setup(m => m.CreateClient(It.IsAny<string>())).Returns(new HttpClient(mh.Object));
+        _httpClientFactoryMock.Setup(m =>
+            m.CreateClient(It.IsAny<string>())).Returns(new HttpClient(mh.Object));
     }
 
-    public static IEnumerable<object[]> GetLatestVersionTestsData => BundleTestCases(
-        new TestCase("200 with correct data")
-            .WithSetup(
-                "httpclientfactory",
-                new Dictionary<string, object>{
-                    {"status code", HttpStatusCode.OK},
-                    {"content", new StringContent(_json_200_with_correct_data)}
-                })
-            .WithExpected("version", new Version("0.1.0"))
+    public class GetLatestVersionTestsData: IEnumerable<object[]>
+    {
+        public record TestParameters(Inputs Inputs, ExpectedResults Expected);
 
-        ,new TestCase("200 but no json")
-            .WithSetup(
-                "httpclientfactory",
-                new Dictionary<string, object>{
-                    {"status code", HttpStatusCode.OK},
-                    {"content", new StringContent(string.Empty)}
-                })
-            .WithExpected("version", null)
+        private static IEnumerable<object[]> TestCases()
+        {
+            yield return new []{
+                new TestCase<TestParameters>("200 with correct data",
+                new TestParameters(
+                    new Inputs{
+                        HttpResponseMessage = new HttpResponseMessage{
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(_json_200_with_correct_data)
+                        }
+                    },
+                    new ExpectedResults{
+                        Version = new Version("0.1.0")
+                    }
+                ))};
 
-        ,new TestCase("200 but tag_name is not present")
-            .WithSetup(
-                "httpclientfactory",
-                new Dictionary<string, object>{
-                    {"status code", HttpStatusCode.OK},
-                    {"content", new StringContent(_json_200_without_tag_name)}
-                })
-            .WithExpected("version", null)
+            yield return new []{
+                new TestCase<TestParameters>("200 but no json",
+                new TestParameters(
+                    new Inputs{
+                        HttpResponseMessage = new HttpResponseMessage{
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(string.Empty)
+                        }
+                    },
+                    new ExpectedResults{
+                        Version = null
+                    }
+                ))};
 
-        ,new TestCase("200 but tag_name is a version string")
-            .WithSetup(
-                "httpclientfactory",
-                new Dictionary<string, object>{
-                    {"status code", HttpStatusCode.OK},
-                    {"content", new StringContent(_json_200_tag_name_is_not_version)}
-                })
-            .WithExpected("version", null)
+            yield return new []{
+                 new TestCase<TestParameters>("200 but tag_name is not present",
+                new TestParameters(
+                    new Inputs{
+                        HttpResponseMessage = new HttpResponseMessage{
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(_json_200_without_tag_name)
+                        }
+                    },
+                    new ExpectedResults{
+                        Version = null
+                    }
+                ))};
 
-        ,new TestCase("400")
-            .WithSetup(
-                "httpclientfactory",
-                new Dictionary<string, object>{
-                    {"status code", HttpStatusCode.BadRequest},
-                    {"content", new StringContent(string.Empty)}
-                })
-            .WithExpected("version", null)
+            yield return new []{
+                 new TestCase<TestParameters>("200 but tag_name is not a version string",
+                new TestParameters(
+                    new Inputs{
+                        HttpResponseMessage = new HttpResponseMessage{
+                            StatusCode = HttpStatusCode.OK,
+                            Content = new StringContent(_json_200_tag_name_is_not_version)
+                        }
+                    },
+                    new ExpectedResults{
+                        Version = null
+                    }
+                ))};
 
-        ,new TestCase("404")
-            .WithSetup(
-                "httpclientfactory",
-                new Dictionary<string, object>{
-                    {"status code", HttpStatusCode.NotFound},
-                    {"content", new StringContent(string.Empty)}
-                })
-            .WithExpected("version", null)
+             yield return new []{
+                 new TestCase<TestParameters>("400",
+                new TestParameters(
+                    new Inputs{
+                        HttpResponseMessage = new HttpResponseMessage{
+                            StatusCode = HttpStatusCode.BadRequest,
+                            Content = new StringContent(string.Empty)
+                        }
+                    },
+                    new ExpectedResults{
+                        Version = null
+                    }
+                ))};
 
-        // timeout
+             yield return new []{
+                 new TestCase<TestParameters>("404",
+                new TestParameters(
+                    new Inputs{
+                        HttpResponseMessage = new HttpResponseMessage{
+                            StatusCode = HttpStatusCode.NotFound,
+                            Content = new StringContent(string.Empty)
+                        }
+                    },
+                    new ExpectedResults{
+                        Version = null
+                    }
+                ))};
 
-        );
+        }
+
+        public IEnumerator<object[]> GetEnumerator() => TestCases().GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public class ExpectedResults
+        {
+            public Version? Version {get; init;}
+        }
+
+        public class Inputs
+        {
+            public required HttpResponseMessage HttpResponseMessage {get; init;}
+        }
+
+    }
 
     private const string _json_200_tag_name_is_not_version = @"
     {

--- a/PeriodTrackerTests/Tests/UpdateServiceTests/GetShouldCheckForUpdates.cs
+++ b/PeriodTrackerTests/Tests/UpdateServiceTests/GetShouldCheckForUpdates.cs
@@ -1,4 +1,3 @@
-
 using Moq;
 using PeriodTracker;
 
@@ -7,11 +6,11 @@ namespace PeriodTrackerTests;
 public partial class UpdateServiceTests
 {
 
-    [Theory, MemberData(nameof(GetShouldCheckForUpdatesTestsData))]
-    public async Task GetShouldCheckForUpdatesTests(TestCase test){
+    [Theory, ClassData(typeof(GetShouldCheckForUpdatesTestsData))]
+    public async Task GetShouldCheckForUpdatesTests(TestCase<GetShouldCheckForUpdatesTestsData.TestParameters> test){
         var testTempDir = _tempDir.CreateTestCaseDirectory(test.Name);
 
-        await SetupDatabase(testTempDir, test.Setups);
+        await SetupDatabase(testTempDir, test.Parameters.Inputs);
 
         using var db = new AppDbContext(CreateDbContextOptions(testTempDir), true);
 
@@ -21,32 +20,65 @@ public partial class UpdateServiceTests
         using var actor = new UpdateService(_httpClientFactoryMock.Object, _dbContextProviderMock.Object);
 
         var act = await actor.GetShouldCheckForUpdates();
-        var exp = (bool)test.Expected["result"]!;
+        var exp = test.Parameters.Expected.Result;
 
         Assert.Equal(exp, act);
     }
 
-    public static IEnumerable<object[]> GetShouldCheckForUpdatesTestsData => BundleTestCases(
-        new TestCase("Time has elapsed")
-            // No setup because the database default is enough.
-            .WithExpected("result", true),
+    public class GetShouldCheckForUpdatesTestsData: IEnumerable<object[]>
+    {
+        public record TestParameters(Inputs Inputs, ExpectedResults Expected);
+        private static IEnumerable<object[]> TestCases()
+        {
+            yield return new []{
+                new TestCase<TestParameters>("Time has elapsed",
+                    new TestParameters(
+                        // No setup because the database default is enough.
+                        new Inputs(),
+                        new ExpectedResults{ Result = true }
+                    ))};
 
-        new TestCase("Time has elapsed - is today")
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"AppState", new object[]{
-                        new object[] {AppStateProperty.NotifyUpdateAvailableNextDate, DateTime.UtcNow.Date},}
-                }})
-            .WithExpected("result", true),
+            yield return new []{
+                new TestCase<TestParameters>("Time has elapsed - is today",
+                    new TestParameters(
+                        new Inputs{
+                            AppStates = new List<AppState>{
+                                new (){
+                                    AppStatePropertyId = AppStateProperty.NotifyUpdateAvailableNextDate,
+                                    Value = DateTime.UtcNow.Date.ToString()
+                                }}},
+                        new ExpectedResults{ Result = true }
+                    ))};
 
-        new TestCase("Time has not elapsed")
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"AppState", new object[]{
-                        new object[] {AppStateProperty.NotifyUpdateAvailableNextDate, DateTime.UtcNow.AddDays(1)},}
-                }})
-            .WithExpected("result", false)
-        );
+            yield return new []{
+                new TestCase<TestParameters>("Time has not elapsed",
+                    new TestParameters(
+                        new Inputs{
+                            AppStates = new List<AppState>{
+                                new (){
+                                    AppStatePropertyId = AppStateProperty.NotifyUpdateAvailableNextDate,
+                                    Value = DateTime.UtcNow.AddDays(1).ToString()
+                                }}},
+                        new ExpectedResults{ Result = false }
+                    ))};
+        }
+
+        public IEnumerator<object[]> GetEnumerator() => TestCases().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public class ExpectedResults
+        {
+            public bool Result { get; init; }
+        }
+
+        public class Inputs: ISeedDataProvider
+        {
+            public List<AppState> AppStates { get; init; } = new ();
+
+            public SeedData GetSeedData() => new SeedData{
+                AppStates = AppStates
+            };
+        }
+    }
 }

--- a/PeriodTrackerTests/Tests/UpdateServiceTests/SetNextNotifyTime.cs
+++ b/PeriodTrackerTests/Tests/UpdateServiceTests/SetNextNotifyTime.cs
@@ -6,11 +6,11 @@ namespace PeriodTrackerTests;
 public partial class UpdateServiceTests
 {
 
-    [Theory, MemberData(nameof(SetNextNotifyTimeTestsData))]
-    public async Task SetNextNotifyTimeTests(TestCase test){
+    [Theory, ClassData(typeof(SetNextNotifyTimeTestsData))]
+    public async Task SetNextNotifyTimeTests(TestCase<SetNextNotifyTimeTestsData.TestParameters> test){
         var testTempDir = _tempDir.CreateTestCaseDirectory(test.Name);
 
-        await SetupDatabase(testTempDir, test.Setups);
+        await SetupDatabase(testTempDir, test.Parameters.Inputs);
 
         using (var db = new AppDbContext(CreateDbContextOptions(testTempDir), true)){
             _dbContextProviderMock.Setup(m => m.GetContext()).Returns(Task.Run(() => db));
@@ -25,44 +25,88 @@ public partial class UpdateServiceTests
 
         using var db2 = new AppDbContext(CreateDbContextOptions(testTempDir), true);
         var actDate = await db2.GetAppStateValue(AppStateProperty.NotifyUpdateAvailableNextDate, Convert.ToDateTime);
-        var expDate = (DateTime)test.Expected["date"]!;
+        var expDate = test.Parameters.Expected.Date;
 
         Assert.Equal(expDate, actDate);
     }
 
-    public static IEnumerable<object[]> SetNextNotifyTimeTestsData => BundleTestCases(
-        new TestCase("Interval is 0")
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"AppState", new object[]{
-                        new object[]{AppStateProperty.NotifyUpdateAvailableInterval, 0}
-                    }}
-                })
-            .WithExpected("date", DateTime.UtcNow.Date)
+    public class SetNextNotifyTimeTestsData: IEnumerable<object[]>
+    {
+        public record TestParameters(Inputs Inputs, ExpectedResults Expected);
 
-        ,new TestCase("Interval is 1")
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"AppState", new object[]{
-                        new object[]{AppStateProperty.NotifyUpdateAvailableInterval, 1}
-                    }}
-                })
-            .WithExpected("date", DateTime.UtcNow.AddDays(1).Date)
+        private static IEnumerable<object[]> TestCases()
+        {
+            yield return new []{
+                new TestCase<TestParameters>("Interval is 0",
+                new TestParameters(
+                    new Inputs{
+                        AppStates = new List<AppState>{
+                            new (){
+                                AppStatePropertyId = AppStateProperty.NotifyUpdateAvailableInterval,
+                                Value = "0"
+                            }}},
+                    new ExpectedResults{
+                        Date = DateTime.UtcNow.Date
+                    }
+                ))};
 
-        ,new TestCase("Interval is 2")
-            // No setup because database default is enough
-            .WithExpected("date", DateTime.UtcNow.AddDays(2).Date)
+            yield return new []{
+                new TestCase<TestParameters>("Interval is 1",
+                new TestParameters(
+                    new Inputs{
+                        AppStates = new List<AppState>{
+                            new (){
+                                AppStatePropertyId = AppStateProperty.NotifyUpdateAvailableInterval,
+                                Value = "1"
+                            }}},
+                    new ExpectedResults{
+                        Date = DateTime.UtcNow.AddDays(1).Date
+                    }
+                ))};
 
-        ,new TestCase("Interval is -1") //just for fun
-            .WithSetup(
-                "database",
-                new Dictionary<string, object[]>{
-                    {"AppState", new object[]{
-                        new object[]{AppStateProperty.NotifyUpdateAvailableInterval, -1}
-                    }}
-                })
-            .WithExpected("date", DateTime.UtcNow.AddDays(-1).Date)
-        );
+            yield return new []{
+                new TestCase<TestParameters>("Interval is 2",
+                new TestParameters(
+                    // No setup because database default is enough
+                    new Inputs(),
+                    new ExpectedResults{
+                        Date = DateTime.UtcNow.AddDays(2).Date
+                    }
+                ))};
+
+            yield return new []{
+                // just for fun
+                new TestCase<TestParameters>("Interval is -1",
+                new TestParameters(
+                    new Inputs{
+                        AppStates = new List<AppState>{
+                            new (){
+                                AppStatePropertyId = AppStateProperty.NotifyUpdateAvailableInterval,
+                                Value = "-1"
+                            }}},
+                    new ExpectedResults{
+                        Date = DateTime.UtcNow.AddDays(-1).Date
+                    }
+                ))};
+        }
+
+        public IEnumerator<object[]> GetEnumerator() => TestCases().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public class ExpectedResults
+        {
+            public DateTime Date { get; init; }
+        }
+
+        public class Inputs: ISeedDataProvider
+        {
+            public List<AppState> AppStates { get; init; } = new ();
+
+            public SeedData GetSeedData() => new SeedData{
+                AppStates = AppStates
+            };
+        }
+    }
+
 }


### PR DESCRIPTION
Refactor test cases to resolve obsolete compiler warnings. This includes updating test data, modifying test methods, and ensuring compatibility with the latest codebase changes.

closes #43